### PR TITLE
React 0.13.x

### DIFF
--- a/Cursor.js
+++ b/Cursor.js
@@ -1,6 +1,7 @@
 var React = require('react');
 var PropTypes = React.PropTypes;
 var emptyFunction = require('react/lib/emptyFunction');
+var merge = require('react/lib/Object.assign');
 
 var Cursor = React.createClass({
 
@@ -35,15 +36,17 @@ var Cursor = React.createClass({
   },
 
   render: function () {
-    var props = this.props;
-    props.style = this.getStyle();
-    props.onMouseDown = this.props.onDragStart;
-    props.onTouchStart = function (e) {
-      e.preventDefault(); // prevent for scroll
-      return this.props.onDragStart.apply(null, arguments);
-    }.bind(this);
-    props.onMouseUp = this.props.onDragEnd;
-    props.onTouchEnd = this.props.onDragEnd;
+    var props = merge({
+      style: this.getStyle(),
+      onMouseDown: this.props.onDragStart,
+      onTouchStart: function (e) {
+        e.preventDefault(); // prevent for scroll
+        return this.props.onDragStart.apply(null, arguments);
+      }.bind(this),
+      onMouseUp: this.props.onDragEnd,
+      onTouchEnd: this.props.onDragEnd
+    }, this.props);
+
     return (
       React.createElement('div', props, this.props.children)
     );

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     ]
   },
   "peerDependencies": {
-    "react": "0.12.x"
+    "react": "0.13.x"
   },
   "author": "xeodou@gmail.com",
   "license": "MIT",
@@ -39,7 +39,7 @@
     "gulp-sass": "^0.7.3",
     "gulp-size": "^1.1.0",
     "jest-cli": "^0.1.18",
-    "react": "^0.12.1",
+    "react": "^0.13.3",
     "reactify": "^0.17.1"
   }
 }


### PR DESCRIPTION
I updated the peerDependencies to react 0.13.x.

After that, React gave me warnings on modifications to the Cursors `props` object.
So I changed it to use `Object.assign` to create a copy of the cursors props.
