### PR TITLE
Change path of empty function to new path necessary in React >= 0.14

### DIFF
--- a/Cursor.js
+++ b/Cursor.js
@@ -1,7 +1,7 @@
 var React = require('react');
 var assign = require('object-assign');
 var PropTypes = React.PropTypes;
-var emptyFunction = require('react/lib/emptyFunction');
+var emptyFunction = require('fbjs/lib/emptyFunction');
 
 var Cursor = React.createClass({
 

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@
 
 var React = require('react');
 var PropTypes = React.PropTypes;
-var emptyFunction = require('react/lib/emptyFunction');
+var emptyFunction = require('fbjs/lib/emptyFunction');
 var assign = require('object-assign');
 var event = require('./event');
 var Cursor = React.createFactory(require('./Cursor'));


### PR DESCRIPTION
This package did not work with React 0.14.0. This change might make it work, but is only a temporary fix.

The React team recommends against accessing anything in /lib, and there were breaking changes in v0.14 that make the emptyFunction require fail. This change temporarily fixes it, by pointing to fbjs/lib/emptyFunction, but as FB says "If you are consuming the code here and you are not also a Facebook project, be prepared for a bad time. APIs may appear or disappear and we may not follow semver strictly..."
