### PR TITLE
Fix touch issues on non-touchscreen in chrome (fixes #15)

### DIFF
--- a/Cursor.js
+++ b/Cursor.js
@@ -1,8 +1,17 @@
 var React = require('react');
 var assign = require('object-assign');
 var PropTypes = React.PropTypes;
+var event = require('./event');
 
 var noop = function () {}
+var buildUnwrappingListener = function(listener) {
+  return function(e) {
+    var unwrappedEvent = e.changedTouches[e.changedTouches.length - 1];
+    unwrappedEvent.stopPropagation = e.stopPropagation.bind(e);
+    unwrappedEvent.preventDefault = e.preventDefault.bind(e);
+    return listener(unwrappedEvent);
+  };
+}
 
 var Cursor = React.createClass({
 
@@ -12,6 +21,7 @@ var Cursor = React.createClass({
     axis: PropTypes.oneOf(['X', 'Y']),
     offset: PropTypes.number,
     onDragStart: PropTypes.func,
+    onDrag: PropTypes.func,
     onDragEnd: PropTypes.func,
     value: PropTypes.number
   },
@@ -26,6 +36,9 @@ var Cursor = React.createClass({
       onDragEnd: noop
     };
   },
+
+  // Mixin events
+  mixins: [event],
 
   getStyle: function () {
     var transform = 'translate' + this.props.axis + '(' + this.props.offset + 'px)';
@@ -44,13 +57,35 @@ var Cursor = React.createClass({
     var i = this.props.position;
     var l = this.props.size;
     props.style = this.getStyle();
-    props.onMouseDown = this.props.onDragStart;
+
+    var mousemoveListener, touchmoveListener, mouseupListener, touchendListener;
+    props.onMouseDown = function () {
+      this.addEvent(window, 'mousemove', mousemoveListener);
+      this.addEvent(window, 'touchmove', touchmoveListener);
+      this.addEvent(window, 'mouseup', mouseupListener);
+      this.addEvent(window, 'touchend', touchendListener);
+
+      return props.onDragStart.apply(null, arguments);
+    }.bind(this);
+
     props.onTouchStart = function (e) {
       e.preventDefault(); // prevent for scroll
-      return this.props.onDragStart.apply(null, arguments);
+      return buildUnwrappingListener(props.onMouseDown)(e);
     }.bind(this);
-    props.onMouseUp = this.props.onDragEnd;
-    props.onTouchEnd = this.props.onDragEnd;
+
+    mousemoveListener = props.onDrag;
+    touchmoveListener = buildUnwrappingListener(mousemoveListener);
+
+    mouseupListener = function () {
+      this.removeEvent(window, 'mousemove', mousemoveListener);
+      this.removeEvent(window, 'touchmove', touchmoveListener);
+      this.removeEvent(window, 'mouseup', mouseupListener);
+      this.removeEvent(window, 'touchend', touchendListener);
+
+      return props.onDragEnd.apply(null, arguments);
+    }.bind(this);
+    touchendListener = buildUnwrappingListener(mouseupListener);
+
     props.zIndex = (i === 0 || i === l + 1) ? 0 : i + 1;
     return props;
   },

--- a/event.js
+++ b/event.js
@@ -2,37 +2,6 @@
 
 var event = {};
 
-// @credits: http://stackoverflow.com/questions/4817029/whats-the-best-way-to-detect-a-touch-screen-device-using-javascript/4819886#4819886
-/* Conditional to fix node server side rendering of component */
-event.isTouchDevice = function () {
-  var isTouchDevice = false;
-  // Check if is Browser
-  if (typeof window !== 'undefined') {
-    isTouchDevice = 'ontouchstart' in window // works on most browsers
-      || 'onmsgesturechange' in window; // works on ie10 on ms surface
-  }
-  return isTouchDevice;
-}
-
-/**
- * simple abstraction for dragging events names
- * */
-event.dragEventFor = (function () {
-  var eventsFor = {
-    touch: {
-      start: 'touchstart',
-      move: 'touchmove',
-      end: 'touchend'
-    },
-    mouse: {
-      start: 'mousedown',
-      move: 'mousemove',
-      end: 'mouseup'
-    }
-  };
-  return eventsFor[event.isTouchDevice() ? 'touch' : 'mouse'];
-})()
-
 event.addEvent = function (el, event, handler) {
   if (!el) {
     return;

--- a/index.js
+++ b/index.js
@@ -301,7 +301,6 @@ var RangeSlider = React.createClass({
     if (this.props.disabled) return;
     // Make it possible to attach event handlers on top of this one
     this.props.onMouseDown(e);
-    e = this.isTouchDevice() ? e.changedTouches[e.changedTouches.length - 1] : e;
     var position = e['page' + this.state.axis];
     var value = this.state.min,
       l = this.state.value.length;
@@ -319,16 +318,12 @@ var RangeSlider = React.createClass({
 
     this.props.onBeforeChange(e, i - 1);
 
-    // Add event handlers
-    this.addEvent(window, this.dragEventFor['move'], this.handleDrag);
-    this.addEvent(window, this.dragEventFor['end'], this.handleDragEnd);
     pauseEvent(e);
   },
 
   handleDrag: function (e) {
     if (this.props.disabled) return;
 
-    e = this.isTouchDevice() ? e.changedTouches[e.changedTouches.length - 1] : e;
     var position = e['page' + this.state.axis],
       diffPosition = position - this.state.startPosition,
       diffValue = (diffPosition / this.state.upperBound) * (this.props.max - this.props.min),
@@ -374,9 +369,6 @@ var RangeSlider = React.createClass({
 
     this.props.onAfterChange(e, this.state.value);
 
-    // Remove event handlers
-    this.removeEvent(window, this.dragEventFor['move'], this.handleDrag);
-    this.removeEvent(window, this.dragEventFor['end'], this.handleDragEnd);
     e.stopPropagation();
   },
 
@@ -393,7 +385,8 @@ var RangeSlider = React.createClass({
     var opts = {
       axis: this.state.axis,
       size: l,
-      onDragEnd: this.handleDragEnd
+      onDragEnd: this.handleDragEnd,
+      onDrag: this.handleDrag,
     }
     if (this.props.cursor) {
       cursors = offsets.map(function (offset, i) {


### PR DESCRIPTION
This PR changes the way mouse/touch handlers are used. Basically, it takes care of handling all possible events without determining whether it runs on a touch screen at initialization time.
This fixes #15 (which is caused by `"ontouchstart" in window` being unreliable in Chrome) and has the added benefit that the slider will always work, when the user switches from touch to non-touch (and vice versa) while using the current website (e.g. for convertible or hybrid computers).

This is also considered as best practice (see http://www.html5rocks.com/en/mobile/touchandmouse/).

I tested the code on Chrome 49, Firefox 40 and IE 11.

The code in this PR might be not the tidiest, but I'm open to suggestions :)
